### PR TITLE
Changed third link and text on JS Basics.

### DIFF
--- a/javascript/js_basics.md
+++ b/javascript/js_basics.md
@@ -47,9 +47,9 @@ This is a fairly long list of things to pay attention to but it should be mostly
 
 ## Your Assignment
 
-2. Read [Javascript is Super Sexy](http://javascriptissexy.com/javascript-is-super-sexy/), which is a good post for getting fired up to learn Javascript.
-1. Finish [the entire Codecademy Javascript track](http://www.codecademy.com/tracks/javascript) (you already did up to lesson 5).
-2. Glance through [Javascript 101 from learn.jquery.com](http://learn.jquery.com/javascript-101/) to fill in gaps in the Codecademy course.  The stuff on scopes and closures will be covered in the later section in more depth.
+1. Read [Javascript is Super Sexy](http://javascriptissexy.com/javascript-is-super-sexy/), which is a good post for getting fired up to learn Javascript.
+2. Finish [the entire Codecademy Javascript track](http://www.codecademy.com/tracks/javascript) (you already did up to lesson 5).
+3. Glance through [Javascript Basics from Mozilla](https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/JavaScript_basics) to review from the Codecademy course.
 
 ## Additional Resources
 


### PR DESCRIPTION
The current link to JQuery's Javascript 101 returns a 404 error, so it would be nice to remove that link and add a new one or simply remove that 3rd part if it's not necessary. 

Here, I substituted the Mozilla JS Basics page, which a lot of people direct beginners to. It covers things a little differently than the original link, but provides a good review of the Codecademy course while showing some of the cool ways that you can use JS on the web. As a beginner, I've been itching to see some basic use of JS on a webpage and this site scratched that itch.
